### PR TITLE
Add support for VARIABLE_PRESENTATION_ENUMERATION

### DIFF
--- a/BlindController/module.php
+++ b/BlindController/module.php
@@ -3292,6 +3292,21 @@ class BlindController extends IPSModuleStrict
                     'MaxValue' => $presentation['MAX']
                 ];
 
+            case VARIABLE_PRESENTATION_ENUMERATION:
+                // "Aufzählung" mit "Rolladen"-Vorlage
+                // OPTIONS ist ein JSON-String mit Value/Caption-Paaren
+                $options = json_decode($presentation['OPTIONS'] ?? '[]', true);
+                if (empty($options)) {
+                    return null;
+                }
+                $values = array_column($options, 'Value');
+                // Konvention wie bei SHUTTER (Rolladen-Vorlage): kleinster Wert = geschlossen, größter = offen
+                // MinValue = offen (max), MaxValue = geschlossen (min) → isMinMaxReversed = true
+                return [
+                    'MinValue' => max($values),
+                    'MaxValue' => min($values)
+                ];
+
             default:
                 //assert(false, sprintf('unsupported presentation: %s with "%s"', $presentation['PRESENTATION'], $propName));
                 trigger_error(sprintf('unsupported presentation: %s with "%s"', $presentation['PRESENTATION'], $propName));


### PR DESCRIPTION
Mit IPS 9.0 und der Variablendarstellung "Aufzählung" tritt Fehler 237 ("Rollladen Level Variable hat kein Profil") auf, da VARIABLE_PRESENTATION_ENUMERATION im default-Zweig von GetPresentationInformation() landet und null zurückgibt.

Fix: Neuer case für VARIABLE_PRESENTATION_ENUMERATION, der die OPTIONS-JSON parsed und MinValue/MaxValue analog zu VARIABLE_PRESENTATION_SHUTTER setzt (max = offen, min = geschlossen).

Getestet: IPS 9.0 (b9a34e92f86a), Raspberry Pi arm64, Homematic LEVEL (Float 0-1), mit Darstellung "Aufzählung".